### PR TITLE
Change in parallelisation of modelTest()

### DIFF
--- a/R/tests.R
+++ b/R/tests.R
@@ -105,7 +105,7 @@ modelTest <- function(x, errors, nsim, bins=NA, runm=NA, timeRange=NA, raw=FALSE
     }
     cragrid <- uncalibrate(as.CalGrid(predgrid), calCurves=calCurves, compact=FALSE, verbose=FALSE)
     cragrid <- cragrid[cragrid$CRA <= max(x$metadata$CRA) & cragrid$CRA >= min(x$metadata$CRA),]
-    sim <- foreach (s = 1:nsim, .combine='rbind', .packages='rcarbon') %dopar% {   #### FS CHANGE
+    sim <- foreach (s = 1:nsim, .combine='cbind', .packages='rcarbon') %dopar% {   #### FS CHANGE
         if (verbose){ setTxtProgressBar(pb, s) }
         randomDates <- sample(cragrid$CRA, replace=TRUE, size=samplesize, prob=cragrid$PrDens)
         randomSDs <- sample(size=length(randomDates), errors, replace=TRUE)

--- a/R/tests.R
+++ b/R/tests.R
@@ -54,11 +54,14 @@
 #' @export
 
 modelTest <- function(x, errors, nsim, bins=NA, runm=NA, timeRange=NA, raw=FALSE, model=c("exponential","explog","custom"), predgrid=NA, calCurves='intcal13', datenormalised=FALSE, spdnormalised=FALSE, ncores=1, fitonly=FALSE, verbose=TRUE){
-
+    
     if (ncores>1&!requireNamespace("doParallel", quietly=TRUE)){	
 	warning("the doParallel package is required for multi-core processing; ncores has been set to 1")
 	ncores=1
-    }	
+    } else {  ### FS ADDITION
+      require(foreach)
+      cl <- makeCluster(ncores)
+    }
     if (verbose){ print("Aggregating observed dates...") }
     if (is.na(bins[1])){
         samplesize <- nrow(x$metadata)
@@ -101,18 +104,19 @@ modelTest <- function(x, errors, nsim, bins=NA, runm=NA, timeRange=NA, raw=FALSE
     }
     cragrid <- uncalibrate(as.CalGrid(predgrid), calCurves=calCurves, compact=FALSE, verbose=FALSE)
     cragrid <- cragrid[cragrid$CRA <= max(x$metadata$CRA) & cragrid$CRA >= min(x$metadata$CRA),]
-    for (s in 1:nsim){
+    sim <- foreach (s = 1:nsim, .combine='rbind', .package='rcarbon') %dopar% {   #### FS CHANGE
         if (verbose){ setTxtProgressBar(pb, s) }
         randomDates <- sample(cragrid$CRA, replace=TRUE, size=samplesize, prob=cragrid$PrDens)
         randomSDs <- sample(size=length(randomDates), errors, replace=TRUE)
-        tmp <- calibrate(x=randomDates,errors=randomSDs, timeRange=timeRange, calCurves=calCurves, normalised=datenormalised, ncores=ncores, verbose=FALSE, calMatrix=TRUE)
+        tmp <- calibrate(x=randomDates,errors=randomSDs, timeRange=timeRange, calCurves=calCurves, normalised=datenormalised, ncores=1, verbose=FALSE, calMatrix=TRUE)
         simDateMatrix <- tmp$calmatrix
-        sim[,s] <- apply(simDateMatrix,1,sum)
-        sim[,s] <- (sim[,s]/sum(sim[,s])) * sum(predgrid$PrDens[predgrid$calBP <= timeRange[1] & predgrid$calBP >= timeRange[2]])
-        if (spdnormalised){ sim[,s] <- (sim[,s]/sum(sim[,s])) }
+        aux <- apply(simDateMatrix,1,sum)  #### FS CHANGE
+        aux <- (aux/sum(aux)) * sum(predgrid$PrDens[predgrid$calBP <= timeRange[1] & predgrid$calBP >= timeRange[2]])  #### FS CHANGE
+        if (spdnormalised){ aux <- (aux/sum(aux)) }  #### FS CHANGE
         if (!is.na(runm)){
-            sim[,s] <- runMean(sim[,s], runm, edge="fill")
+            aux <- runMean(aux, runm, edge="fill")  #### FS CHANGE
         }
+	aux  #### FS ADDITION
     }
     if (verbose){ close(pb) }
     ## Envelope, z-scores, global p-value

--- a/R/tests.R
+++ b/R/tests.R
@@ -58,8 +58,7 @@ modelTest <- function(x, errors, nsim, bins=NA, runm=NA, timeRange=NA, raw=FALSE
     if (ncores>1&!requireNamespace("doParallel", quietly=TRUE)){	
 	warning("the doParallel package is required for multi-core processing; ncores has been set to 1")
 	ncores=1
-    } else {  ### FS ADDITION
-      require(foreach)
+    } else {
       cl <- parallel::makeCluster(ncores)
       doParallel::registerDoParallel(cl)
     }
@@ -105,19 +104,19 @@ modelTest <- function(x, errors, nsim, bins=NA, runm=NA, timeRange=NA, raw=FALSE
     }
     cragrid <- uncalibrate(as.CalGrid(predgrid), calCurves=calCurves, compact=FALSE, verbose=FALSE)
     cragrid <- cragrid[cragrid$CRA <= max(x$metadata$CRA) & cragrid$CRA >= min(x$metadata$CRA),]
-    sim <- foreach (s = 1:nsim, .combine='cbind', .packages='rcarbon') %dopar% {   #### FS CHANGE
+    sim <- foreach (s = 1:nsim, .combine='cbind', .packages='rcarbon') %dopar% {
         if (verbose){ setTxtProgressBar(pb, s) }
         randomDates <- sample(cragrid$CRA, replace=TRUE, size=samplesize, prob=cragrid$PrDens)
         randomSDs <- sample(size=length(randomDates), errors, replace=TRUE)
         tmp <- calibrate(x=randomDates,errors=randomSDs, timeRange=timeRange, calCurves=calCurves, normalised=datenormalised, ncores=1, verbose=FALSE, calMatrix=TRUE)
         simDateMatrix <- tmp$calmatrix
-        aux <- apply(simDateMatrix,1,sum)  #### FS CHANGE
-        aux <- (aux/sum(aux)) * sum(predgrid$PrDens[predgrid$calBP <= timeRange[1] & predgrid$calBP >= timeRange[2]])  #### FS CHANGE
-        if (spdnormalised){ aux <- (aux/sum(aux)) }  #### FS CHANGE
+        aux <- apply(simDateMatrix,1,sum)
+        aux <- (aux/sum(aux)) * sum(predgrid$PrDens[predgrid$calBP <= timeRange[1] & predgrid$calBP >= timeRange[2]])
+        if (spdnormalised){ aux <- (aux/sum(aux)) }
         if (!is.na(runm)){
-            aux <- runMean(aux, runm, edge="fill")  #### FS CHANGE
+            aux <- runMean(aux, runm, edge="fill")
         }
-	aux  #### FS ADDITION
+	aux
     }
     if (verbose){ close(pb) }
     ## Envelope, z-scores, global p-value

--- a/R/tests.R
+++ b/R/tests.R
@@ -60,7 +60,8 @@ modelTest <- function(x, errors, nsim, bins=NA, runm=NA, timeRange=NA, raw=FALSE
 	ncores=1
     } else {  ### FS ADDITION
       require(foreach)
-      cl <- makeCluster(ncores)
+      cl <- parallel::makeCluster(ncores)
+      doParallel::registerDoParallel(cl)
     }
     if (verbose){ print("Aggregating observed dates...") }
     if (is.na(bins[1])){

--- a/R/tests.R
+++ b/R/tests.R
@@ -104,7 +104,7 @@ modelTest <- function(x, errors, nsim, bins=NA, runm=NA, timeRange=NA, raw=FALSE
     }
     cragrid <- uncalibrate(as.CalGrid(predgrid), calCurves=calCurves, compact=FALSE, verbose=FALSE)
     cragrid <- cragrid[cragrid$CRA <= max(x$metadata$CRA) & cragrid$CRA >= min(x$metadata$CRA),]
-    sim <- foreach (s = 1:nsim, .combine='rbind', .package='rcarbon') %dopar% {   #### FS CHANGE
+    sim <- foreach (s = 1:nsim, .combine='rbind', .packages='rcarbon') %dopar% {   #### FS CHANGE
         if (verbose){ setTxtProgressBar(pb, s) }
         randomDates <- sample(cragrid$CRA, replace=TRUE, size=samplesize, prob=cragrid$PrDens)
         randomSDs <- sample(size=length(randomDates), errors, replace=TRUE)


### PR DESCRIPTION
I've polished my earlier hack to change the parallelisation of modelTest(), as discussed by email, from parallelising calibrate() to parallelising across the number of simulations