### PR TITLE
Allow binPrep function to accept other agglomeration methods

### DIFF
--- a/R/aggregation.R
+++ b/R/aggregation.R
@@ -8,7 +8,8 @@
 #' 
 #' @param sites a vector of character strings (or number to coerce to character) of all sites or site phases. If character strings are used these should not contain underscores (see also below)
 #' @param ages a vector of uncalibrated conventional radiocarbon ages or a \code{CalDates} class object obtained using the \code{\link{calibrate}} function.
-#' @param h a single numeric value passed to \code{\link{hclust}} control degree of grouping of similar ages in a phase site.
+#' @param h a single numeric value passed to \code{\link{cutree}} control degree of grouping of similar ages in a phase site.
+#' @param method the agglomeration method to be used, passed on to \code{\link{hclust}}. Defaults to "complete" as in \code{\link{hclust}}.
 #'
 #' @details If \code{ages} is a \code{CalDates} class object, median dates are used for the clustering.
 #'
@@ -18,7 +19,7 @@
 #' @import stats
 #' @import utils
 #' @export
-binPrep <- function(sites, ages, h){
+binPrep <- function(sites, ages, h, method = "complete"){
     
     if(any(grepl("_", sites)))
     {
@@ -35,7 +36,7 @@ binPrep <- function(sites, ages, h){
     for  (x in 1:length(unique(sites))){
         index <- which(sites==unique(sites)[x])
         if (length(index)>1){
-            clusters[index] <- paste(unique(sites)[x],cutree(hclust(dist(ages[index])),h=h),sep="_")
+            clusters[index] <- paste(unique(sites)[x],cutree(hclust(dist(ages[index]), method = method),h=h),sep="_")
         }
         if (length(index)==1){
             clusters[index] <- paste(unique(sites)[x],"1",sep="_")


### PR DESCRIPTION
The default agglomeration method in `stats::hclust` is fine, but other clustering methods might provide more intuitive results. For instance, method "single" can be used for the single linkage method, where "h" then becomes the minimum distance between consecutive dates.

I also made a minor correction: `h` is a parameter in `stats::cutree`, not `stats::hclust`.

See reprex below:

``` r
library(rcarbon)

dates <- c(600, 676, 677, 684, 684, 685, 712, 713, 747, 776, 804, 921, 921, 922, 925, 980)
names(dates) <- dates
sites <- rep(1, 16)

# Default with a cut at h=100 would give you four clusters
hc <- stats::hclust(stats::dist(dates),
                    method = "complete")
dd <- as.dendrogram(hc)
dd.reorder <- reorder(dd, wts = order(dates))
plot(dd.reorder)
abline(h = 100, col = "red")
```

![](https://i.imgur.com/BO9Dkpe.png)

``` r
tibble::tibble(
  ages = dates,
  bins = rcarbon::binPrep(sites = sites,
                          ages = dates,
                          h = 100)
)
#> Registered S3 method overwritten by 'cli':
#>   method     from    
#>   print.boxx spatstat
#> # A tibble: 16 x 2
#>     ages bins 
#>    <dbl> <chr>
#>  1   600 1_1  
#>  2   676 1_2  
#>  3   677 1_2  
#>  4   684 1_2  
#>  5   684 1_2  
#>  6   685 1_2  
#>  7   712 1_2  
#>  8   713 1_2  
#>  9   747 1_2  
#> 10   776 1_3  
#> 11   804 1_3  
#> 12   921 1_4  
#> 13   921 1_4  
#> 14   922 1_4  
#> 15   925 1_4  
#> 16   980 1_4

# method='single' splits only at gaps > h, which produces two clusters
hc <- stats::hclust(stats::dist(dates),
                    method = "single")
dd <- as.dendrogram(hc)
dd.reorder <- reorder(dd, wts = order(dates))
plot(dd.reorder)
abline(h = 100, col = "red")
```

![](https://i.imgur.com/m1aj538.png)

``` r
tibble::tibble(
  ages = dates,
  bins = rcarbon::binPrep(sites = sites,
                          ages = dates,
                          h = 100,
                          method = "single")
)
#> # A tibble: 16 x 2
#>     ages bins 
#>    <dbl> <chr>
#>  1   600 1_1  
#>  2   676 1_1  
#>  3   677 1_1  
#>  4   684 1_1  
#>  5   684 1_1  
#>  6   685 1_1  
#>  7   712 1_1  
#>  8   713 1_1  
#>  9   747 1_1  
#> 10   776 1_1  
#> 11   804 1_1  
#> 12   921 1_2  
#> 13   921 1_2  
#> 14   922 1_2  
#> 15   925 1_2  
#> 16   980 1_2
```

<sup>Created on 2020-03-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>