### PR TITLE
Fast calibration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rcarbon
 Title: Calibration and Analysis of Radiocarbon Dates
-Version: 1.4.0
+Version: 1.4.1
 Authors@R: c(person("Andrew","Bevan", role=c("aut"),email="andrew.bevan@gmail.com"),
 	     person("Enrico","Crema", role=c("aut","cre"),email="enrico.crema@gmail.com"),
 	     person("R. Kyle","Bocinsky",role=c("ctb"),email="bocinsky@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,14 @@
+# Version 1.4.1 (ongoing)
+* UPDATE: Improved performance of the `calibrate()` function (c.a 300-400% faster)
+* Bug fix: Fixed color matching and improved label placing  in the `multiplot` function.
+
 # Version 1.4.0 (15 August 2020)
 * IntCal20, ShCal20, and Marine20 curves added, with IntCal20 as default calibration curve for `calibrate()`.
 
 # Version 1.3.3 (4 August 2020)
 * Minor changes on NAMESPACE and test environment to ensure CRAN checks for all operating systems
 
-#  Verson 1.3.2 (25 July 2020)zo
+#  Verson 1.3.2 (25 July 2020)
 * Bug fix : `F14C=TRUE` was producting an error message in `calibrate()` after refactoring in version 1.3.1. 
 * Bug fix : fixed error in the handling of `resErrors` (Delta R error) for  marine reservoir effect.
 * NEW: `stackspd()` creates a set of multiple SPDs as an object of class `stackCalSPD` with a dedicated plot function.

--- a/R/calibration-helpers.R
+++ b/R/calibration-helpers.R
@@ -7,11 +7,11 @@ normalise_densities <- function(dens,eps) {
 }
 
 # calibrates in F14C space
-F14C_calibration <- function(age, error, calBP, calcurve, eps) {
-  F14 <- exp(calcurve[,2]/-8033) 
-  F14Error <-  F14*calcurve[,3]/8033 
-  calf14 <- approx(calcurve[,1], F14, xout=calBP)$y 
-  calf14error <-  approx(calcurve[,1], F14Error, xout=calBP)$y 
+F14C_calibration <- function(age, error, calf14,calf14error, eps) {
+  # F14 <- exp(calcurve[,2]/-8033) 
+  # F14Error <-  F14*calcurve[,3]/8033 
+  # calf14 <- approx(calcurve[,1], F14, xout=calBP)$y 
+  # calf14error <-  approx(calcurve[,1], F14Error, xout=calBP)$y 
   f14age <- exp(age/-8033) 
   f14err <- f14age*error/8033 
   p1 <- (f14age - calf14)^2 
@@ -23,9 +23,8 @@ F14C_calibration <- function(age, error, calBP, calcurve, eps) {
 }
 
 # calibrates in 14C BP space
-BP14C_calibration <- function(age, error, calBP, calcurve, eps) {
-  mu <- approx(calcurve[,1], calcurve[,2], xout=calBP)$y
-  tau <- error^2 + approx(calcurve[,1], calcurve[,3], xout=calBP)$y^2
+BP14C_calibration <- function(age, error, mu, tau2, eps) {
+  tau <- error^2 + tau2
   dens <- dnorm(age, mean=mu, sd=sqrt(tau))
   dens[dens < eps] <- 0
   return(dens)

--- a/R/calibration.R
+++ b/R/calibration.R
@@ -116,9 +116,9 @@ calibrate.default <- function(x, errors, ids=NA, dateDetails=NA, calCurves='intc
               F14Error <-  F14*cctmp[,3]/8033 
               calf14 <- approx(cctmp[,1], F14, xout=calBPrange)$y 
               calf14error <-  approx(cctmp[,1], F14Error, xout=calBPrange)$y 
-              cclist2[[tmp[a]]] <- list(calf14=calf14,calf14error=calf14error)
+              cclist2[[1]] <- list(calf14=calf14,calf14error=calf14error,calBPrange=calBPrange)
             } else {
-            cclist2[[1]] = list(mu=stats::approx(cctmp[,1], cctmp[,2], xout = )$y,tau2 = stats::approx(cctmp[,1], cctmp[,3], xout = calBPrange)$y^2,calBPrange=calBPrange)
+              cclist2[[1]] = list(mu=stats::approx(cctmp[,1], cctmp[,2], xout = calBPrange)$y,tau2 = stats::approx(cctmp[,1], cctmp[,3], xout = calBPrange)$y^2,calBPrange=calBPrange)
             } 
         } 
     } else if (!all(calCurves %in% c("intcal13","intcal20","shcal13","shcal20","marine13","marine20","intcal13nhpine16","shcal13shkauri16"))){

--- a/R/calibration.R
+++ b/R/calibration.R
@@ -109,7 +109,7 @@ calibrate.default <- function(x, errors, ids=NA, dateDetails=NA, calCurves='intc
             calCurves <- rep("custom",length(x))
             cclist2 <- vector(mode="list", length=1)
             names(cclist2) <- "custom"
-            calBPrange = seq(max(cctmp$CALBP),min(cctmp$CALBP),-1)
+            calBPrange = seq(max(cctmp[,1]),min(cctmp[,1]),-1)
             if (F14C)
             {
               F14 <- exp(cctmp[,2]/-8033) 
@@ -223,7 +223,6 @@ calibrate.default <- function(x, errors, ids=NA, dateDetails=NA, calCurves='intc
       calmat[as.character(sublist[[a]]$calBP),a] <- sublist[[a]]$PrDens
     }
   }
-  
   ## clean-up and results
   if (length(x)>1 & verbose){ close(pb) }
   df <- data.frame(DateID=ids, CRA=x, Error=errors, Details=dateDetails, CalCurve=calCurves,ResOffsets=resOffsets, ResErrors=resErrors, StartBP=timeRange[1], EndBP=timeRange[2], Normalised=normalised, F14C=F14C, CalEPS=eps, stringsAsFactors=FALSE)

--- a/R/calibration.R
+++ b/R/calibration.R
@@ -116,7 +116,7 @@ calibrate.default <- function(x, errors, ids=NA, dateDetails=NA, calCurves='intc
               F14Error <-  F14*cctmp[,3]/8033 
               calf14 <- approx(cctmp[,1], F14, xout=calBPrange)$y 
               calf14error <-  approx(cctmp[,1], F14Error, xout=calBPrange)$y 
-              cclist2[[tmp[a]]] - list(calf14=calf14,calf14error=calf14error)
+              cclist2[[tmp[a]]] <- list(calf14=calf14,calf14error=calf14error)
             } else {
             cclist2[[1]] = list(mu=stats::approx(cctmp[,1], cctmp[,2], xout = )$y,tau2 = stats::approx(cctmp[,1], cctmp[,3], xout = calBPrange)$y^2,calBPrange=calBPrange)
             } 
@@ -140,7 +140,7 @@ calibrate.default <- function(x, errors, ids=NA, dateDetails=NA, calCurves='intc
         F14Error <-  F14*cctmp[,3]/8033 
         calf14 <- approx(cctmp[,1], F14, xout=calBPrange)$y 
         calf14error <-  approx(cctmp[,1], F14Error, xout=calBPrange)$y 
-        cclist2[[tmp[a]]] - list(calf14=calf14,calf14error=calf14error,calBPrange=calBPrange)
+        cclist2[[tmp[a]]] <- list(calf14=calf14,calf14error=calf14error,calBPrange=calBPrange)
       } else {
       cclist2[[tmp[a]]] = list(mu=stats::approx(cctmp[,1], cctmp[,2], xout = calBPrange)$y,tau2 = stats::approx(cctmp[,1], cctmp[,3], xout = calBPrange)$y^2,calBPrange=calBPrange)}
     }
@@ -201,6 +201,7 @@ calibrate.default <- function(x, errors, ids=NA, dateDetails=NA, calCurves='intc
     }
     #res <- data.frame(calBP=calBPrange,PrDens=dens)
     #res <- res[which(calBPrange<=timeRange[1]&calBPrange>=timeRange[2]),]
+    calBPrange = cclist2[[calCurves[b]]]$calBPrange
     calBP = calBPrange[which(calBPrange<=timeRange[1]&calBPrange>=timeRange[2])]
     PrDens = dens[which(calBPrange<=timeRange[1]&calBPrange>=timeRange[2])]
     # if (anyNA(res$PrDens))

--- a/R/calibration.R
+++ b/R/calibration.R
@@ -232,7 +232,7 @@ calibrate.default <- function(x, errors, ids=NA, dateDetails=NA, calCurves='intc
     reslist[["grids"]] <- NA
     reslist[["calmatrix"]] <- calmat
   } else {
-    reslist[["grids"]] <- lapply(sublist,function(x){tmp=data.frame(CalBP=x[[1]],PrDens=x[[2]]);class(tmp)=append(class(tmp),"calGrid");return(tmp)})
+    reslist[["grids"]] <- lapply(sublist,function(x){tmp=data.frame(calBP=x[[1]],PrDens=x[[2]]);class(tmp)=append(class(tmp),"calGrid");return(tmp)})
     reslist[["calmatrix"]] <- NA
   }
   class(reslist) <- c("CalDates",class(reslist))


### PR DESCRIPTION
Major update of `calibrate` function for improving speed performance. Results of microbenchmark test (with 100 iterations) returned an average of 465 milliseconds for calibrating 100 random dates, in contrast to 1744 milliseconds of the current CRAN version (1.4.0). 

The following test was carried out to check differences in the output between the two versions:
```
#### This block was repeated for the current CRAN version (1.4.0) and the new version with fatser calibration (1.4.1) ####
library(rcarbon)
s = sessionInfo()
v = s$otherPkgs[[which(names(s$otherPkgs)=='rcarbon')]]$Version
set.seed(123)
n=10
x=sample(3000:10000,size=n)
y=rep(20,n)
multi=sample(c('intcal13','intcal20','shcal13','marine20','shcal20'),size=n,replace=TRUE)
custom = mixCurves('intcal20','marine20',p=0.7,resOffsets=300,resErrors=20)
resOffsets=rep(50,n)
resErrors=rep(20,n)

# Parameters
F14C=c(TRUE,FALSE)
normalised=c(TRUE,FALSE)
calMatrix=c(TRUE,FALSE)
ncores=c(TRUE,FALSE)
curve=c('intcal20','marine13','custom','multi')
ncores=c(1,2)

params=expand.grid(F14C=F14C,normalised=normalised,calMatrix=calMatrix,ncores=ncores,curve=curve)

tempList = vector('list',length=nrow(params))

for (i in 1:nrow(params))
{
  if (params$curve[i]=='intcal20')
  {
    tempList[[i]]=calibrate(x,y,calMatrix=params$calMatrix[i],normalised=params$normalised[i],ncores=params$ncores[i],F14C=params$F14C[i])
  }
  
  if (params$curve[i]=='multi')
  {
    tempList[[i]]=calibrate(x,y,calMatrix=params$calMatrix[i],normalised=params$normalised[i],ncores=params$ncores[i],F14C=params$F14C[i],calCurves=multi)
  }
  
  if (params$curve[i]=='custom')
  {
    tempList[[i]]=calibrate(x,y,calMatrix=params$calMatrix[i],normalised=params$normalised[i],ncores=params$ncores[i],F14C=params$F14C[i],calCurves=custom)
  }
  
  if (params$curve[i]=='marine13')
  {
    tempList[[i]]=calibrate(x,y,calMatrix=params$calMatrix[i],normalised=params$normalised[i],ncores=params$ncores[i],F14C=params$F14C[i],calCurves='marine13',resErrors=resErrors,resOffsets=resOffsets)
  }
  
}

assign(paste0('calibrateRes_',v),tempList)
save(list=paste0('calibrateRes_',v),file=paste0('calibrateRes_',v,'.RData'))
```
```
#### This block was used to check equivalence #####
load('./calibrateRes_1.4.1.RData')
load('./calibrateRes_1.4.0.RData')
library(testthat)

length(calibrateRes_1.4.0)==length(calibrateRes_1.4.1)
check = vector(length=length(calibrateRes_1.4.0))
for (i in 1:length(calibrateRes_1.4.0))
{
  if(all(!is.na(calibrateRes_1.4.0[[i]]$calmatrix)&all(!is.na(calibrateRes_1.4.1[[i]]$calmatrix))))
     {
    check[i]=all(calibrateRes_1.4.0[[i]]$calmatrix==calibrateRes_1.4.1[[i]]$calmatrix)
  } else {
    check[i]=all(sapply(1:10,function(x,a,b){all(a$grids[[x]]==b$grids[[x]])},a=calibrateRes_1.4.0[[i]],b=calibrateRes_1.4.1[[i]]))
     }
}
all(check)
expect_equivalent(calibrateRes_1.4.0,calibrateRes_1.4.1)
compare(calibrateRes_1.4.0,calibrateRes_1.4.1)
```
The two sets of dates are equivalent, with the only difference being the row.,names of the grid objects of each calibrated date (i.e. `rownames(x$grids[[1]])` would be different between 1.4.0 and 1.4.1). This is unlikely to cause any issue. 





```